### PR TITLE
Add healthcheck script and update Dockerfile to use it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,12 @@ FROM alpine:latest
 RUN apk --no-cache add curl
 
 WORKDIR /
+
 COPY ./LICENSE .
 COPY --from=builder ./shellyplug-exporter .
+COPY ./healthcheck.sh /healthcheck.sh
+RUN chmod +x /shellyplug-exporter /healthcheck.sh
 
-RUN chmod +x /shellyplug-exporter
-
-HEALTHCHECK --interval=30s --timeout=5s CMD curl -f "http://localhost:${EXPORTER_PORT:-5000}/health" || exit 1
+HEALTHCHECK --interval=30s --timeout=5s CMD /healthcheck.sh
 
 ENTRYPOINT ["/shellyplug-exporter", "run"]

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Docker healthcheck for shellyplug-exporter
-# Reads exporter port from /run/shellyplug-exporter.info if present, else defaults to 5000
+# Reads exporter port from /tmp/shellyplug-exporter.info if present, else defaults to 5000
 
 INFO_FILE="/tmp/shellyplug-exporter.info"
 PORT="5000"

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -6,7 +6,10 @@ INFO_FILE="/run/shellyplug-exporter.info"
 PORT="5000"
 
 if [ -f "$INFO_FILE" ]; then
-  PORT=$(grep '^EXPORTER_PORT=' "$INFO_FILE" | cut -d'=' -f2)
+  EXTRACTED_PORT=$(grep '^EXPORTER_PORT=' "$INFO_FILE" | cut -d'=' -f2)
+  if [ -n "$EXTRACTED_PORT" ]; then
+    PORT="$EXTRACTED_PORT"
+  fi
 fi
 
 curl -fs "http://localhost:${PORT}/health" || exit 1

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -12,4 +12,4 @@ if [ -f "$INFO_FILE" ]; then
   fi
 fi
 
-curl -fs "http://localhost:${PORT}/health" || exit 1
+curl -fs --max-time 5 "http://localhost:${PORT}/health" || exit 1

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Docker healthcheck for shellyplug-exporter
+# Reads exporter port from /run/shellyplug-exporter.info if present, else defaults to 5000
+
+INFO_FILE="/run/shellyplug-exporter.info"
+PORT="5000"
+
+if [ -f "$INFO_FILE" ]; then
+  PORT=$(grep '^EXPORTER_PORT=' "$INFO_FILE" | cut -d'=' -f2)
+fi
+
+curl -fs "http://localhost:${PORT}/health" || exit 1

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -2,7 +2,7 @@
 # Docker healthcheck for shellyplug-exporter
 # Reads exporter port from /run/shellyplug-exporter.info if present, else defaults to 5000
 
-INFO_FILE="/run/shellyplug-exporter.info"
+INFO_FILE="/tmp/shellyplug-exporter.info"
 PORT="5000"
 
 if [ -f "$INFO_FILE" ]; then

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -12,4 +12,4 @@ if [ -f "$INFO_FILE" ]; then
   fi
 fi
 
-curl -fs --max-time 5 "http://localhost:${PORT}/health" || exit 1
+curl -fs --max-time 4 "http://localhost:${PORT}/health" || exit 1

--- a/src/shellyplug_exporter/cli.cr
+++ b/src/shellyplug_exporter/cli.cr
@@ -22,7 +22,7 @@ module ShellyplugExporter
       begin
         File.write("/tmp/shellyplug-exporter.info", "EXPORTER_PORT=#{port}\n")
       rescue ex
-        STDERR.puts "Warning: Could not write /run/shellyplug-exporter.info: #{ex.message}"
+        STDERR.puts "Warning: Could not write /tmp/shellyplug-exporter.info: #{ex.message}"
       end
 
       Server.new(plugs, port).run

--- a/src/shellyplug_exporter/cli.cr
+++ b/src/shellyplug_exporter/cli.cr
@@ -18,6 +18,13 @@ module ShellyplugExporter
       plugs = config.plugs.map { |plug_config| Plug.new(plug_config) }
       port = exporter_port || config.exporter_port
 
+      # Write only exporter port to a known file for healthcheck
+      begin
+        File.write("/run/shellyplug-exporter.info", "EXPORTER_PORT=#{port}\n")
+      rescue ex
+        STDERR.puts "Warning: Could not write /run/shellyplug-exporter.info: #{ex.message}"
+      end
+
       Server.new(plugs, port).run
     end
 

--- a/src/shellyplug_exporter/cli.cr
+++ b/src/shellyplug_exporter/cli.cr
@@ -20,7 +20,7 @@ module ShellyplugExporter
 
       # Write only exporter port to a known file for healthcheck
       begin
-        File.write("/run/shellyplug-exporter.info", "EXPORTER_PORT=#{port}\n")
+        File.write("/tmp/shellyplug-exporter.info", "EXPORTER_PORT=#{port}\n")
       rescue ex
         STDERR.puts "Warning: Could not write /run/shellyplug-exporter.info: #{ex.message}"
       end


### PR DESCRIPTION
- Introduced a new healthcheck.sh script for monitoring the service health.
- Updated Dockerfile to copy the healthcheck script and set it as the healthcheck command.
- Added logic to write the exporter port to a file for healthcheck access.